### PR TITLE
Add `strip_unneeded_headers_before_save`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ jobs:
           command: |-
             bundle exec rspec --format RspecJunitFormatter \
               --out /tmp/test-results/rspec/results.xml --format progress
+      # actually not necessary for test results to be collected, but these files
+      # won't show up in the web UI otherwise
+      - store_artifacts:
+          path: /tmp/rspec/
+          destination: rspec
       - store_test_results:
           path: /tmp/rspec/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.0 2024-02-17
+## Added
+- Added `strip_unneeded_headers_before_save` method to keep cassette size down
+
 # v0.1.4 2020-12-03
 
 ### Updated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_vcr_harness (0.1.4)
+    nxt_vcr_harness (0.2.0)
       rspec (~> 3.0)
       vcr (~> 6.0)
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,71 @@ Or install it yourself as:
 
 ## Usage
 
-NxtVcrHarness currently has two features. You can use it to find vcr cassettes that are not being used when you 
+NxtVcrHarness provides three features.
+
+### 1. List unused cassettes after each test run.
+You can use it to find vcr cassettes that are not being used when you 
 run your test suite. Enable it by calling `NxtVcrHarness.track_cassettes_if(...your condition in here...)`. 
 Note that the output only makes sense when you run your complete test suite. 
 If you run only a subset all cassettes that are used by your other test will be included too.
 
-The second feature is that you can enable your custom :vcr tag by calling `NxtVcrHarness.enable_vcr_tag`. This will 
+### 2. Use custom VCR tag
+You can enable your custom :vcr tag by calling `NxtVcrHarness.enable_vcr_tag`. This will 
 automatically name your vcr cassettes based on the your rspec example and the surrounding contexts. You can also 
 setup default cassette options for your vcr tag. 
 
 ```ruby
 NxtVcrHarness.enable_vcr_tag(tag_name: :my_vcr_tag, default_cassette_options: { ... })
+```
+
+### 3. Keep cassettes small by removing unneeded headers
+API responses typically contain useful headers, such as information about rate limits and pagination,
+but also many more unnecessary headers.
+You can drastically reduce the size of your cassettes by stripping unnecessary headers before saving.
+
+```ruby
+# After VCR.configure:
+NxtVcrHarness.strip_unneeded_headers_before_save
+```
+
+By default, nxt_vcr_harness will remove the following kinds of headers (case-insensitive) from responses:
+- CORS headers (`Access-Control-*`)
+- Headers for browsers (`X-Frame-Options`, `Content-Security-Policy`, `Strict-Transport-Security`, `X-Xss-Protection`, `Expect-Ct`...)
+- Headers for browsers/proxies/CDNs (`Cache-Control`, `Etag`, `Vary`...)
+- Common cloud provider headers (CloudFlare, AWS)
+- Server details (`Server-Timing`, `X-Powered-By`, `X-Runtime`, `Via`, `Date`)
+
+From requests, `Accept-Encoding` and `Expect` headers will be removed.
+
+See `NxtVcrHarness::UnneededHeaders.default_headers_to_strip` for the full list of removed headers.
+
+You can add or override headers to be removed (regexes or strings):
+
+```ruby
+NxtVcrHarness.strip_unneeded_headers_before_save do |headers_to_strip|
+  headers_to_strip[:response] << /X-Dixa-.+/i
+end
+```
+
+To run this slimming on existing cassettes, you can create a simple Ruby script or Rake task, for example::
+
+```rb
+require 'vcr'
+require 'nxt_vcr_harness'
+
+headers_to_strip = NxtVcrHarness::UnneededHeaders.default_headers_to_strip
+headers_to_strip[:responses] << /X-Dixa-.+/i
+
+task slim_cassettes: :environment do
+  Dir[Rails.root.join('spec/fixtures/vcr_cassettes/**/**.yml')].each do |file_path|
+    cassette = ::YAML.load(File.read(file_path))
+    cassette['http_interactions'].each do |interaction|
+      NxtVcrHarness::UnneededHeaders.strip(interaction['request']['headers'], headers_to_strip[:requests])
+      NxtVcrHarness::UnneededHeaders.strip(interaction['response']['headers'], headers_to_strip[:responses])
+    end
+    File.write(file_path, VCR.cassette_serializers[:yaml].serialize(cassette))
+  end
+end
 ```
 
 ## Development

--- a/lib/nxt_vcr_harness/unneeded_headers.rb
+++ b/lib/nxt_vcr_harness/unneeded_headers.rb
@@ -1,0 +1,74 @@
+module NxtVcrHarness
+  module UnneededHeaders
+    REQUEST_HEADERS = %w[
+      Accept-Encoding
+      Expect
+    ].freeze
+
+    BROWSER_HEADERS = [
+      /Access-Control-.+/i,
+      'Alt-Svc',
+      /(X-)?Content-Security-Policy.*/i,
+      'Cache-Control',
+      'Etag',
+      'Expect-Ct',
+      'NEL',
+      'Referrer-Policy',
+      'Report-To',
+      'Reporting-Endpoints',
+      'Set-Cookie',
+      'Strict-Transport-Security',
+      'Vary',
+      /X-(Content-Type-Options|Download-Options|Frame-Options|Permitted-Cross-Domain-Policies|Webkit-Csp|Xss-Protection)/i,
+    ].freeze
+
+    SERVER_DETAILS = [
+      'Date',
+      'Server',
+      'Server-Timing',
+      /X-(Powered-By|Runtime|Served-By|Server-Elapsed)/i,
+      /X-Envoy-(Decorator-Operation|Upstream-Service-Time)/i,
+      'Via',
+    ].freeze
+
+    AMAZON_HEADERS = [
+      /X-Amzn?-.+/i,
+      'X-Cache',
+    ].freeze
+
+    CLOUDFLARE_HEADERS = [
+      /Cf-.+/i,
+    ].freeze
+
+    RESPONSE_HEADERS = [
+      *BROWSER_HEADERS,
+      *SERVER_DETAILS,
+      *AMAZON_HEADERS,
+      *CLOUDFLARE_HEADERS,
+    ].freeze
+
+    def default_headers_to_strip
+      {
+        requests: UnneededHeaders::REQUEST_HEADERS.dup,
+        responses: UnneededHeaders::RESPONSE_HEADERS.dup,
+      }
+    end
+
+    def strip(headers_hash, headers_to_strip)
+      headers_hash.delete_if do |k, v|
+        headers_to_strip.any? do |header|
+          case header
+          when String
+            k == header || k == header.downcase
+          when Regexp
+            k.match?(header)
+          else
+            raise ArgumentError, "Unexpected key type in headers_to_strip hash: #{header}"
+          end
+        end
+      end
+    end
+
+    module_function :default_headers_to_strip, :strip
+  end
+end

--- a/lib/nxt_vcr_harness/version.rb
+++ b/lib/nxt_vcr_harness/version.rb
@@ -1,3 +1,3 @@
 module NxtVcrHarness
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/spec/unneeded_headers_spec.rb
+++ b/spec/unneeded_headers_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe NxtVcrHarness::UnneededHeaders do
+  describe '#strip' do
+    let(:headers_hash) do
+      {
+        'X-Monty-Python-Life-Of-Brian' => '1979',
+        'monty-python-flying-circus' => '1969',
+        'X-The-Hobbit' => '2012',
+        'x-monty-python-holy-grail' => '1975',
+      }
+    end
+
+    it 'strips headers by regex' do
+      expect(described_class.strip(headers_hash, [/(X-)?Monty-Python-*/i])).to eq({
+        'X-The-Hobbit' => '2012',
+      })
+    end
+
+    it 'strips headers by string' do
+      expect(described_class.strip(headers_hash, ['x-Monty-Python-holy-grail'])).to eq({
+        'X-Monty-Python-Life-Of-Brian' => '1979',
+        'monty-python-flying-circus' => '1969',
+        'X-The-Hobbit' => '2012',
+      })
+    end
+
+    it 'strips headers by string and regex' do
+      expect(described_class.strip(headers_hash, ['x-monty-python-holy-grail', /hobbit/i])).to eq({
+        'X-Monty-Python-Life-Of-Brian' => '1979',
+        'monty-python-flying-circus' => '1969',
+      })
+    end
+
+    it 'raises an error for an unknown key type' do
+      expect { described_class.strip(headers_hash, [55]) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Following on from the proposal [on Slack](https://getsafe.slack.com/archives/C03DT3HD953/p1707487965863219), we want to get rid of unneeded headers in our VCR cassettes to keep the size down, and make them more maintainable.

This PR adds this functionality to the nxt_vcr_harness gem, so all that's needed is to call `NxtVcrHarness.strip_unneeded_headers_before_save`. The gem comes with a blacklist of common unneeded headers which will be removed.

Since this is a public gem, I've kept the list relatively light. Custom headers for services we use can be added in our gems, for instance:

```rb

NxtVcrHarness.strip_unneeded_headers_before_save do |headers_to_strip|
  headers_to_strip[:responses].concat [
    'X-Dixa-Rid', # Dixa
    'X-Mp-Request-Id', # Mixpanel
    'X-Sanity-Shard', # Sanity
    # Twilio
    'X-Shenanigans',
    'Twilio-Request-Duration',
  ]
end
```

For existing cassettes, I'm running a simple Rake task across our services (example in the README).

[BE-85](https://hellogetsafe.atlassian.net/browse/BE-85)

[BE-85]: https://hellogetsafe.atlassian.net/browse/BE-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ